### PR TITLE
Adding SWE Units to SweVariable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.21.1 (2024-03-18)
+
+* Add a field `unit` to the SweVariable type
+* Add these units to the static SWE variables
+
 # v0.21.0 (2024-03-12)
 
 * Update some variable text for sensors, platforms, and algorithms

--- a/VERSION.env
+++ b/VERSION.env
@@ -1,1 +1,1 @@
-export SERVER_VERSION="v0.21.0"
+export SERVER_VERSION="v0.21.1"

--- a/snow_today_webapp_ingest/types_/variables.py
+++ b/snow_today_webapp_ingest/types_/variables.py
@@ -27,6 +27,7 @@ class SweVariable(BaseModel):
     no_data_value: int
     colormap_id: int
     transparent_zero: bool
+    unit: str
 
 
 class SweVariablesIndex(RootModel):

--- a/static/snow-water-equivalent/variables.json
+++ b/static/snow-water-equivalent/variables.json
@@ -8,7 +8,8 @@
     "transparentZero": false,
     "noDataValue": 255,
     "valueRange": [0, 100],
-    "colormapValueRange": [0, 50]
+    "colormapValueRange": [0, 50],
+    "unit": "cm"
   },
   "swe_delta_inches": {
     "longName": "Change in Snow Water Equivalent",
@@ -19,7 +20,8 @@
     "transparentZero": false,
     "noDataValue": 255,
     "valueRange": [-4, 4],
-    "colormapValueRange": [-2, 2]
+    "colormapValueRange": [-2, 2],
+    "unit": "cm"
   },
   "swe_normalized_pct": {
     "longName": "Percentage of Median Snow Water Equivalent",
@@ -30,6 +32,7 @@
     "transparentZero": false,
     "noDataValue": 255,
     "valueRange": [0, 200],
-    "colormapValueRange": [45, 155]
+    "colormapValueRange": [45, 155],
+    "unit": "%"
   }
 }


### PR DESCRIPTION
From Issue #68.

This adds the "unit", whether it be cm or %, to the SweVariable. It also updates the available SWE variables to include their respective unit.

This allows the units to be printed on the front end consistently.